### PR TITLE
Update requirement with python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==1.0.3
+python-dateutil==2.7.5


### PR DESCRIPTION
You had forgotten to add this requirement in the `requirements.txt` file, which would not allow us to run the project.